### PR TITLE
Fix typo in JSON object - lang IT

### DIFF
--- a/lang/dates_it.json
+++ b/lang/dates_it.json
@@ -34,7 +34,7 @@
         "may": "Maggio",
         "june": "Giugno",
         "july": "Luglio",
-        "august": "Augosto",
+        "august": "Agosto",
         "september": "Settembre",
         "october": "Ottobre",
         "november": "Novembre",


### PR DESCRIPTION
Fixed typo error in file `dates_it.json`, `"months":` array - from `"august": "Augosto",` to `"august": "Agosto",`